### PR TITLE
Adjust homepage in metadata/about.conf

### DIFF
--- a/metadata/about.conf
+++ b/metadata/about.conf
@@ -1,4 +1,4 @@
-homepage = http://www.github.com/mawww
+homepage = https://www.github.com/mawww/maww
 summary = mawww's supplemental repository
 description = mawww's tasty exhereses
 owner = mawww <frrrwww@gmail.com>


### PR DESCRIPTION
#### Overview

Current homepage leads to `maww`'s overview (https://www.github.com/mawww)

Adjust this to the repository's homepage: https://www.github.com/mawww/maww