### PR TITLE
lmms: fix rpmalloc branch name

### DIFF
--- a/packages/media-sound/lmms/lmms-1.2.2.exheres-0
+++ b/packages/media-sound/lmms/lmms-1.2.2.exheres-0
@@ -13,6 +13,8 @@ SCM_ecm_REPOSITORY="https://github.com/KDE/extra-cmake-modules"
 SCM_rpmalloc_REPOSITORY="https://github.com/rampantpixels/rpmalloc.git"
 SCM_CHECKOUT_TO="qt5-x11embed"
 SCM_rpmalloc_UNPACK_TO="${PNV}/src/3rdparty/rpmalloc/rpmalloc"
+SCM_rpmalloc_BRANCH="main"
+SCM_rpmalloc_REVISION="b5bdc18051bb74a22f0bde4bcc90b01cf590b496"
 
 SCM_SECONDARY_REPOSITORIES="ecm rpmalloc"
 SCM_EXTERNAL_REFS="3rdparty/ECM:ecm"


### PR DESCRIPTION
Branch name and [commit HASH](https://github.com/LMMS/lmms/tree/v1.2.2/src/3rdparty/rpmalloc) was defined, so that the build goes through